### PR TITLE
Added ref main

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,22 +34,27 @@ dependencies:
   ailia:
     git:
       url: https://github.com/axinc-ai/ailia-sdk-flutter.git
+      ref: main
 
   ailia_audio:
     git:
       url: https://github.com/axinc-ai/ailia-audio-flutter.git
+      ref: main
 
   ailia_tokenizer:
     git:
       url: https://github.com/axinc-ai/ailia-tokenizer-flutter.git
+      ref: main
 
   ailia_speech:
     git:
       url: https://github.com/axinc-ai/ailia-speech-flutter.git
+      ref: main
 
   ailia_voice:
     git:
       url: https://github.com/axinc-ai/ailia-voice-flutter.git
+      ref: main
 
   path_provider:
   wav:


### PR DESCRIPTION
ref: mainが存在しない場合にパッケージを読み込めない環境があるようなので、pubspec.yamlにref: mainを追加しました。