### PR TITLE
Whisperのmic_streamのサンプル作成

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -40,5 +40,18 @@ end
 post_install do |installer|
   installer.pods_project.targets.each do |target|
     flutter_additional_ios_build_settings(target)
+
+    # Start of the permission_handler configuration
+    target.build_configurations.each do |config|
+
+      #  Preprocessor definitions can be found in: https://github.com/Baseflow/flutter-permission-handler/blob/master/permission_handler_apple/ios/Classes/PermissionHandlerEnums.h
+      config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= [
+        '$(inherited)',
+
+        ## dart: PermissionGroup.microphone
+        'PERMISSION_MICROPHONE=1',
+        ]
+
+    end
   end
 end

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -3,6 +3,8 @@ PODS:
     - Flutter
   - ailia_audio (0.0.1):
     - Flutter
+  - ailia_llm (0.0.1):
+    - Flutter
   - ailia_speech (0.0.1):
     - Flutter
   - ailia_tokenizer (0.0.1):
@@ -12,25 +14,34 @@ PODS:
   - audioplayers_darwin (0.0.1):
     - Flutter
   - Flutter (1.0.0)
+  - mic_stream (0.0.1):
+    - Flutter
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
+  - permission_handler_apple (9.3.0):
+    - Flutter
 
 DEPENDENCIES:
   - ailia (from `.symlinks/plugins/ailia/ios`)
   - ailia_audio (from `.symlinks/plugins/ailia_audio/ios`)
+  - ailia_llm (from `.symlinks/plugins/ailia_llm/ios`)
   - ailia_speech (from `.symlinks/plugins/ailia_speech/ios`)
   - ailia_tokenizer (from `.symlinks/plugins/ailia_tokenizer/ios`)
   - ailia_voice (from `.symlinks/plugins/ailia_voice/ios`)
   - audioplayers_darwin (from `.symlinks/plugins/audioplayers_darwin/ios`)
   - Flutter (from `Flutter`)
+  - mic_stream (from `.symlinks/plugins/mic_stream/ios`)
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
+  - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
 
 EXTERNAL SOURCES:
   ailia:
     :path: ".symlinks/plugins/ailia/ios"
   ailia_audio:
     :path: ".symlinks/plugins/ailia_audio/ios"
+  ailia_llm:
+    :path: ".symlinks/plugins/ailia_llm/ios"
   ailia_speech:
     :path: ".symlinks/plugins/ailia_speech/ios"
   ailia_tokenizer:
@@ -41,19 +52,26 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/audioplayers_darwin/ios"
   Flutter:
     :path: Flutter
+  mic_stream:
+    :path: ".symlinks/plugins/mic_stream/ios"
   path_provider_foundation:
     :path: ".symlinks/plugins/path_provider_foundation/darwin"
+  permission_handler_apple:
+    :path: ".symlinks/plugins/permission_handler_apple/ios"
 
 SPEC CHECKSUMS:
-  ailia: 37774b5dfd9d4f3f1210d24c4865d1ec60c129bf
-  ailia_audio: 6640642df6b80c6157aa012831e49b2628e048f1
-  ailia_speech: 1b165dc4dc4846b7f12d39e2378f4173de9e91c3
-  ailia_tokenizer: f3ab0f73a9c93030a0fa6a3ae003c78e0a26d948
-  ailia_voice: e85dbbf35881dee44d8975931ac4ed39f9c23d5c
+  ailia: dfd9d82d32f8858e00de4dfbbd215f055b9f1846
+  ailia_audio: 5d473878c872e2adea458b313d87ec39fafe2939
+  ailia_llm: 4821657054a82884d0282b2e361b8fe58018dfb4
+  ailia_speech: 0141beec68eb0296b1faee725958e516152eaa8d
+  ailia_tokenizer: 4ef32d01e2e47fff31851673d5a104cd52e407e0
+  ailia_voice: e1e4de56e23fde371980c529efc2ec740655d479
   audioplayers_darwin: 877d9a4d06331c5c374595e46e16453ac7eafa40
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
+  mic_stream: 28787bfcfcfc68e17fad15050baf5929f1d10901
   path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
+  permission_handler_apple: 9878588469a2b0d0fc1e048d9f43605f92e6cec2
 
-PODFILE CHECKSUM: 819463e6a0290f5a72f145ba7cde16e8b6ef0796
+PODFILE CHECKSUM: 149c2aef65f906a80c3092dea80bc4c5514f3ddd
 
 COCOAPODS: 1.15.2

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -8,7 +8,6 @@
 
 /* Begin PBXBuildFile section */
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
-		2C3C65F055EDE65B0CF9F3F8 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 26F8B3F937293C73856C628D /* Pods_Runner.framework */; };
 		331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807B294A618700263BE5 /* RunnerTests.swift */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
@@ -61,7 +60,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2C3C65F055EDE65B0CF9F3F8 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -188,6 +186,7 @@
 				97C146EC1CF9000F007C117D /* Resources */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
 				A56A6A50BCB31D6796D59F9E /* [CP] Embed Pods Frameworks */,
+				921FCED54F56600742BECDF6 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -319,6 +318,23 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
+		921FCED54F56600742BECDF6 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -348,7 +364,8 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			shellScript = "
+";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -47,5 +47,7 @@
 	</array>
 	<key>FLTEnableImpeller</key>
 	<false />
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Microphone access required</string>
 </dict>
 </plist>

--- a/ios/Runner/Runner.entitlements
+++ b/ios/Runner/Runner.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.kernel.increased-memory-limit</key>
+	<true/>
+</dict>
+</plist>

--- a/lib/audio_processing/whisper.dart
+++ b/lib/audio_processing/whisper.dart
@@ -292,7 +292,7 @@ class AudioProcessingWhisper {
     return modelList;
   }
 
-  Future<void> open(File onnx_encoder_file, File onnx_decoder_file, File vad_file, int env_id, String type, Function intermediateCallback, Function messageCallback, Function finishCallback) async{
+  Future<void> open(File onnx_encoder_file, File onnx_decoder_file, File vad_file, int env_id, String type, String lang, Function intermediateCallback, Function messageCallback, Function finishCallback) async{
     bool virtualMemory = false;
     int typeId = 0;
     if (type == "whisper_tiny"){
@@ -316,7 +316,6 @@ class AudioProcessingWhisper {
       Directory path = await getTemporaryDirectory();
       AiliaModel.setTemporaryCachePath(path.path);
     }
-    String lang = "auto"; // auto or ja
     _ailiaSpeechModel.init(intermediateCallback, messageCallback, finishCallback, onnx_encoder_file, onnx_decoder_file, vad_file, typeId, false, lang, true, env_id, virtualMemory);
   }
 

--- a/lib/audio_processing/whisper.dart
+++ b/lib/audio_processing/whisper.dart
@@ -274,7 +274,7 @@ class AudioProcessingWhisper {
       modelList.add("whisper");
       modelList.add("decoder_small_fix_kv_cache.opt3.onnx");
     }
-    if (type == "whisper_medium"){
+    if (type == "whisper_medium" || type == "whisper_medium_with_virtual_memory"){
       modelList.add("whisper");
       modelList.add("encoder_medium.opt3.onnx");
       modelList.add("whisper");
@@ -301,7 +301,7 @@ class AudioProcessingWhisper {
     if (type == "whisper_small"){
       typeId = ailia_speech_dart.AILIA_SPEECH_MODEL_TYPE_WHISPER_MULTILINGUAL_SMALL;
     }
-    if (type == "whisper_medium"){
+    if (type == "whisper_medium" || type == "whisper_medium_with_virtual_memory"){
       // Please add com.apple.developer.kernel.increased-memory-limit for iOS
       typeId = ailia_speech_dart.AILIA_SPEECH_MODEL_TYPE_WHISPER_MULTILINGUAL_MEDIUM;
     }
@@ -309,7 +309,7 @@ class AudioProcessingWhisper {
       // Please add com.apple.developer.kernel.increased-memory-limit for iOS
       typeId = ailia_speech_dart.AILIA_SPEECH_MODEL_TYPE_WHISPER_MULTILINGUAL_LARGE_V3;
     }
-    if (type == "whisper_large_v3_turbo_with_virtual_memory"){
+    if (type == "whisper_large_v3_turbo_with_virtual_memory" || type == "whisper_medium_with_virtual_memory"){
       virtualMemory = true;
     }
     if (virtualMemory){

--- a/lib/audio_processing/whisper.dart
+++ b/lib/audio_processing/whisper.dart
@@ -1,17 +1,260 @@
+import 'dart:isolate';
 import 'dart:io';
 import 'dart:math';
 
-import 'package:flutter/material.dart';
 import 'package:path_provider/path_provider.dart';
-import 'package:wav/wav.dart';
 
-import 'package:flutter/services.dart';
 import 'package:ailia_speech/ailia_speech.dart' as ailia_speech_dart;
 import 'package:ailia_speech/ailia_speech_model.dart';
 import 'package:ailia/ailia_model.dart';
 
+void speechToTextIsolateFunc(SendPort initialReplyTo) {
+  final receivePort = ReceivePort();
+  final interruptPort = ReceivePort();
+  initialReplyTo.send({
+    "sendPort": receivePort.sendPort,
+    "interruptPort": interruptPort.sendPort
+  });
+
+  late AiliaSpeechModel ailiaSpeechToText;
+
+  // 終了の割り込みメッセージ
+  bool interrupt = false;
+  interruptPort.listen((message) {
+    interrupt = true;
+  });
+
+  // 音声認識ジョブの処理
+  receivePort.listen((message) {
+    SendPort answerPort = message["answerPort"];
+
+    if (message["cmd"] == "initialize") {
+      ailiaSpeechToText = AiliaSpeechModel();
+      ailiaSpeechToText.create(
+        message["liveTranscribe"],
+        false,
+        message["envId"],
+        virtualMemory:message["virtualMemory"],
+      );
+      ailiaSpeechToText.open(
+        message["encoderFile"],
+        message["decoderFile"],
+        message["vadEnable"] ? message["vadFile"] : null,
+        message["language"],
+        message["modelType"],
+      );
+      return;
+    }
+
+    if (message["cmd"] == "terminate") {
+      ailiaSpeechToText.finalizeInputData();
+      while (!ailiaSpeechToText.isComplete() && interrupt == false) {
+        var result = ailiaSpeechToText.transcribe();
+        if (result.isNotEmpty) {
+          answerPort.send({
+            "intermediate": false,
+            "terminate": false,
+            "text": result,
+          });
+        }
+      }
+      ailiaSpeechToText.reset();
+      ailiaSpeechToText.close();
+      answerPort.send({
+        "intermediate": false,
+        "terminate": true,
+        "text": null,
+      });
+      return;
+    }
+
+    if (message["cmd"] == "transcribe") {
+      void intermediateCallback(textMessage) {
+        SpeechText text = SpeechText(
+          textMessage,
+          0,
+          0,
+          0,
+          0,
+        );
+        List<SpeechText> result = [text];
+        answerPort.send({
+          "intermediate": true,
+          "terminate": false,
+          "text": result,
+        });
+      }
+
+      ailiaSpeechToText.setIntermediateCallback(intermediateCallback);
+
+      ailiaSpeechToText.pushInputData(
+        message["chunk"],
+        message["sampleRate"],
+        message["channels"],
+      );
+
+      while (ailiaSpeechToText.isBuffered() && interrupt == false) {
+        var result = ailiaSpeechToText.transcribe();
+        if (result.isNotEmpty) {
+          answerPort.send({
+            "intermediate": false,
+            "terminate": false,
+            "text": result,
+          });
+        }
+      }
+      return;
+    }
+
+    print("unknown cmd");
+  });
+}
+
+class SpeechToTextIsolate {
+  late ReceivePort receivePort;
+  late Isolate isolate;
+  late SendPort sendPort;
+  late SendPort interruptPort;
+  late ReceivePort answerPort;
+  bool _isTerminateFlag = false;
+  bool _isInitializeFlag = false;
+  bool _isIntermediateFlag = false;
+  bool _isInterruptFlag = false;
+
+  Future<void> init(
+    Function intermediateCallback,
+    Function messageCallback,
+    Function finishCallback,
+    File encoderFile,
+    File decoderFile,
+    File vadFile,
+    int modelType,
+    bool liveTranscribe,
+    String language,
+    bool vadEnable,
+    int envId,
+    bool virtualMemory,
+  ) async {
+    _isTerminateFlag = false;
+    _isInterruptFlag = false;
+    receivePort = ReceivePort();
+    isolate = await Isolate.spawn(
+      speechToTextIsolateFunc,
+      receivePort.sendPort,
+    );
+    var message = await receivePort.first;
+    sendPort = message["sendPort"] as SendPort;
+    interruptPort = message["interruptPort"] as SendPort;
+    answerPort = ReceivePort();
+    answerPort.listen((message) async {
+      if (message["intermediate"] == true) {
+        _isIntermediateFlag = true;
+        intermediateCallback(message["text"]);
+      } else {
+        if (message["terminate"] == true) {
+          finishCallback();
+        } else {
+          messageCallback(message["text"]);
+        }
+      }
+    });
+
+    var args = {
+      "answerPort": answerPort.sendPort,
+      "cmd": "initialize",
+      "encoderFile": encoderFile,
+      "decoderFile": decoderFile,
+      "vadFile": vadFile,
+      "liveTranscribe": liveTranscribe,
+      "language": language,
+      "modelType": modelType,
+      "vadEnable": vadEnable,
+      "envId": envId,
+      "virtualMemory": virtualMemory
+    };
+    sendPort.send(args);
+
+    _isInitializeFlag = true;
+    _isIntermediateFlag = false;
+  }
+
+  void send(List<double> chunk, int sampleRate, int channels) {
+    if (!_isInitializeFlag) {
+      print("Warning : send : not initialized");
+      return;
+    }
+
+    // 音声認識が長時間CPUを使わないようにメッセージを1秒ごとに分割する
+    int chunkSize = sampleRate;
+    for (int i = 0; i < chunk.length; i += chunkSize) {
+      final isLast = i + chunkSize >= chunk.length;
+      final end = isLast ? chunk.length : i + chunkSize;
+      var args = {
+        "answerPort": answerPort.sendPort,
+        "cmd": "transcribe",
+        "chunk": chunk.sublist(i, end),
+        "sampleRate": sampleRate,
+        "channels": channels
+      };
+      sendPort.send(args);
+    }
+  }
+
+  bool isTerminate() {
+    return _isTerminateFlag;
+  }
+
+  bool isIntermediate() {
+    return _isIntermediateFlag;
+  }
+
+  // キューを最後まで処理をして終了する
+  void terminate() {
+    if (_isTerminateFlag) {
+      return;
+    }
+    if (!_isInitializeFlag) {
+      print("Warning : terminate : not initialized");
+      return;
+    }
+    _isTerminateFlag = true;
+    var args = {
+      "answerPort": answerPort.sendPort,
+      "cmd": "terminate",
+    };
+    sendPort.send(args);
+  }
+
+  // 以降のキューの認識をスキップする
+  void interrupt() {
+    if (_isInterruptFlag) {
+      return;
+    }
+    if (!_isInitializeFlag) {
+      print("Warning : terminate : not initialized");
+      return;
+    }
+    _isInterruptFlag = true;
+    var args = {
+      "cmd": "interrupt",
+    };
+    interruptPort.send(args);
+  }
+
+  void close() {
+    if (!_isInitializeFlag) {
+      print("Warning : close : not initialized");
+      return;
+    }
+    isolate.kill();
+    receivePort.close();
+    answerPort.close();
+    _isInitializeFlag = false;
+  }
+}
+
 class AudioProcessingWhisper {
-  final AiliaSpeechModel _ailiaSpeechModel = AiliaSpeechModel();
+  final SpeechToTextIsolate _ailiaSpeechModel = SpeechToTextIsolate();
 
   List<String> getModelList(String type){
     List<String> modelList = List<String>.empty(growable: true);
@@ -49,62 +292,8 @@ class AudioProcessingWhisper {
     return modelList;
   }
 
-  void _intermediateCallback(String text){
-    print(text);
-  }
-
-  String _transcribeOneShot(Wav wav){
-      // One shot feed mode
-      String transcribeResult = "";
-      List<double> pcm = List<double>.empty(growable: true);
-
-      for (int i = 0; i < wav.channels[0].length; ++i) {
-        for (int j = 0; j < wav.channels.length; ++j){
-          pcm.add(wav.channels[j][i]);
-        }
-      }
-
-      _ailiaSpeechModel.pushInputData(pcm, wav.samplesPerSecond, wav.channels.length);
-      _ailiaSpeechModel.finalizeInputData(); // for one shot
-
-      List<SpeechText> texts = _ailiaSpeechModel.transcribeBatch();
-      for (int i = 0; i < texts.length; i++){
-        transcribeResult = transcribeResult + texts[i].text;
-      }
-
-      return transcribeResult;
-  }
-
-  String _transcribeStep(Wav wav){
-      // chunk feed mode
-      String transcribeResult = "";
-      int chunkSize = wav.samplesPerSecond;
-      for (int t = 0; t < wav.channels[0].length; t += chunkSize){
-        List<double> pcm = List<double>.empty(growable: true);
-
-        for (int i = t; i < min(t + chunkSize, wav.channels[0].length); ++i) {
-          for (int j = 0; j < wav.channels.length; ++j){
-            pcm.add(wav.channels[j][i]);
-          }
-        }
-
-        _ailiaSpeechModel.pushInputData(pcm, wav.samplesPerSecond, wav.channels.length);
-        if (t + chunkSize >= wav.channels[0].length){
-          _ailiaSpeechModel.finalizeInputData();
-        }
-
-        List<SpeechText> texts = _ailiaSpeechModel.transcribeBatch();
-        for (int i = 0; i < texts.length; i++){
-          transcribeResult = transcribeResult + texts[i].text;
-        }
-      }
-
-      return transcribeResult;
-  }
-
-  Future<String> transcribe(Wav wav, File onnx_encoder_file, File onnx_decoder_file, File vad_file, int env_id, String type) async{
+  Future<void> open(File onnx_encoder_file, File onnx_decoder_file, File vad_file, int env_id, String type, Function intermediateCallback, Function messageCallback, Function finishCallback) async{
     bool virtualMemory = false;
-    _ailiaSpeechModel.create(false, false, env_id, virtualMemory:virtualMemory);
     int typeId = 0;
     if (type == "whisper_tiny"){
       typeId = ailia_speech_dart.AILIA_SPEECH_MODEL_TYPE_WHISPER_MULTILINGUAL_TINY;
@@ -128,24 +317,15 @@ class AudioProcessingWhisper {
       AiliaModel.setTemporaryCachePath(path.path);
     }
     String lang = "auto"; // auto or ja
-    _ailiaSpeechModel.open(onnx_encoder_file, onnx_decoder_file, vad_file, lang, typeId);
+    _ailiaSpeechModel.init(intermediateCallback, messageCallback, finishCallback, onnx_encoder_file, onnx_decoder_file, vad_file, typeId, false, lang, true, env_id, virtualMemory);
+  }
 
-    String transcribeResult = "";
+  void send(List<double> pcm, int samplesPerSecond){
+    _ailiaSpeechModel.send(pcm, samplesPerSecond, 1);
+  }
 
-    //_ailiaSpeechModel.setIntermediateCallback(_intermediateCallback);
-
-    int startTime = DateTime.now().millisecondsSinceEpoch;
-
-    //transcribeResult = _transcribeOneShot(wav);
-    transcribeResult = _transcribeStep(wav);
-
-    int endTime = DateTime.now().millisecondsSinceEpoch;
-
-    transcribeResult = transcribeResult + "\nprocessing time : ${(endTime - startTime) / 1000} sec for ${(wav.channels[0].length / wav.samplesPerSecond)} sec audio.";
-
+  void close(){
     _ailiaSpeechModel.close();
-
-    return transcribeResult;
   }
 
 }

--- a/lib/audio_processing/whisper.dart
+++ b/lib/audio_processing/whisper.dart
@@ -324,6 +324,10 @@ class AudioProcessingWhisper {
     _ailiaSpeechModel.send(pcm, samplesPerSecond, 1);
   }
 
+  void terminate(){
+    _ailiaSpeechModel.terminate();
+  }
+
   void close(){
     _ailiaSpeechModel.close();
   }

--- a/lib/audio_processing/whisper_streaming.dart
+++ b/lib/audio_processing/whisper_streaming.dart
@@ -1,0 +1,296 @@
+// Whisper Speech To Text Streaming Processing
+
+import 'dart:isolate';
+import 'dart:io';
+import 'dart:math';
+
+import 'package:path_provider/path_provider.dart';
+
+import 'package:ailia_speech/ailia_speech.dart' as ailia_speech_dart;
+import 'package:ailia_speech/ailia_speech_model.dart';
+import 'package:ailia/ailia_model.dart';
+
+void speechToTextIsolateFunc(SendPort initialReplyTo) {
+  final receivePort = ReceivePort();
+  final interruptPort = ReceivePort();
+  initialReplyTo.send({
+    "sendPort": receivePort.sendPort,
+    "interruptPort": interruptPort.sendPort
+  });
+
+  late AiliaSpeechModel ailiaSpeechToText;
+
+  // 終了の割り込みメッセージ
+  bool interrupt = false;
+  interruptPort.listen((message) {
+    interrupt = true;
+  });
+
+  // 音声認識ジョブの処理
+  receivePort.listen((message) {
+    SendPort answerPort = message["answerPort"];
+
+    if (message["cmd"] == "initialize") {
+      ailiaSpeechToText = AiliaSpeechModel();
+      ailiaSpeechToText.create(
+        message["liveTranscribe"],
+        false,
+        message["envId"],
+        virtualMemory:message["virtualMemory"],
+      );
+      ailiaSpeechToText.open(
+        message["encoderFile"],
+        message["decoderFile"],
+        message["vadEnable"] ? message["vadFile"] : null,
+        message["language"],
+        message["modelType"],
+      );
+      return;
+    }
+
+    if (message["cmd"] == "terminate") {
+      ailiaSpeechToText.finalizeInputData();
+      while (!ailiaSpeechToText.isComplete() && interrupt == false) {
+        var result = ailiaSpeechToText.transcribe();
+        if (result.isNotEmpty) {
+          answerPort.send({
+            "intermediate": false,
+            "terminate": false,
+            "text": result,
+          });
+        }
+      }
+      ailiaSpeechToText.reset();
+      ailiaSpeechToText.close();
+      answerPort.send({
+        "intermediate": false,
+        "terminate": true,
+        "text": null,
+      });
+      return;
+    }
+
+    if (message["cmd"] == "transcribe") {
+      void intermediateCallback(textMessage) {
+        SpeechText text = SpeechText(
+          textMessage,
+          0,
+          0,
+          0,
+          0,
+        );
+        List<SpeechText> result = [text];
+        answerPort.send({
+          "intermediate": true,
+          "terminate": false,
+          "text": result,
+        });
+      }
+
+      ailiaSpeechToText.setIntermediateCallback(intermediateCallback);
+
+      ailiaSpeechToText.pushInputData(
+        message["chunk"],
+        message["sampleRate"],
+        message["channels"],
+      );
+
+      while (ailiaSpeechToText.isBuffered() && interrupt == false) {
+        var result = ailiaSpeechToText.transcribe();
+        if (result.isNotEmpty) {
+          answerPort.send({
+            "intermediate": false,
+            "terminate": false,
+            "text": result,
+          });
+        }
+      }
+      return;
+    }
+
+    print("unknown cmd");
+  });
+}
+
+class SpeechToTextIsolate {
+  late ReceivePort receivePort;
+  late Isolate isolate;
+  late SendPort sendPort;
+  late SendPort interruptPort;
+  late ReceivePort answerPort;
+  bool _isTerminateFlag = false;
+  bool _isInitializeFlag = false;
+  bool _isIntermediateFlag = false;
+  bool _isInterruptFlag = false;
+
+  Future<void> init(
+    Function intermediateCallback,
+    Function messageCallback,
+    Function finishCallback,
+    File encoderFile,
+    File decoderFile,
+    File vadFile,
+    int modelType,
+    bool liveTranscribe,
+    String language,
+    bool vadEnable,
+    int envId,
+    bool virtualMemory,
+  ) async {
+    _isTerminateFlag = false;
+    _isInterruptFlag = false;
+    receivePort = ReceivePort();
+    isolate = await Isolate.spawn(
+      speechToTextIsolateFunc,
+      receivePort.sendPort,
+    );
+    var message = await receivePort.first;
+    sendPort = message["sendPort"] as SendPort;
+    interruptPort = message["interruptPort"] as SendPort;
+    answerPort = ReceivePort();
+    answerPort.listen((message) async {
+      if (message["intermediate"] == true) {
+        _isIntermediateFlag = true;
+        intermediateCallback(message["text"]);
+      } else {
+        if (message["terminate"] == true) {
+          finishCallback();
+        } else {
+          messageCallback(message["text"]);
+        }
+      }
+    });
+
+    var args = {
+      "answerPort": answerPort.sendPort,
+      "cmd": "initialize",
+      "encoderFile": encoderFile,
+      "decoderFile": decoderFile,
+      "vadFile": vadFile,
+      "liveTranscribe": liveTranscribe,
+      "language": language,
+      "modelType": modelType,
+      "vadEnable": vadEnable,
+      "envId": envId,
+      "virtualMemory": virtualMemory
+    };
+    sendPort.send(args);
+
+    _isInitializeFlag = true;
+    _isIntermediateFlag = false;
+  }
+
+  void send(List<double> chunk, int sampleRate, int channels) {
+    if (!_isInitializeFlag) {
+      print("Warning : send : not initialized");
+      return;
+    }
+
+    // 音声認識が長時間CPUを使わないようにメッセージを1秒ごとに分割する
+    int chunkSize = sampleRate;
+    for (int i = 0; i < chunk.length; i += chunkSize) {
+      final isLast = i + chunkSize >= chunk.length;
+      final end = isLast ? chunk.length : i + chunkSize;
+      var args = {
+        "answerPort": answerPort.sendPort,
+        "cmd": "transcribe",
+        "chunk": chunk.sublist(i, end),
+        "sampleRate": sampleRate,
+        "channels": channels
+      };
+      sendPort.send(args);
+    }
+  }
+
+  bool isTerminate() {
+    return _isTerminateFlag;
+  }
+
+  bool isIntermediate() {
+    return _isIntermediateFlag;
+  }
+
+  // キューを最後まで処理をして終了する
+  void terminate() {
+    if (_isTerminateFlag) {
+      return;
+    }
+    if (!_isInitializeFlag) {
+      print("Warning : terminate : not initialized");
+      return;
+    }
+    _isTerminateFlag = true;
+    var args = {
+      "answerPort": answerPort.sendPort,
+      "cmd": "terminate",
+    };
+    sendPort.send(args);
+  }
+
+  // 以降のキューの認識をスキップする
+  void interrupt() {
+    if (_isInterruptFlag) {
+      return;
+    }
+    if (!_isInitializeFlag) {
+      print("Warning : terminate : not initialized");
+      return;
+    }
+    _isInterruptFlag = true;
+    var args = {
+      "cmd": "interrupt",
+    };
+    interruptPort.send(args);
+  }
+
+  void close() {
+    if (!_isInitializeFlag) {
+      print("Warning : close : not initialized");
+      return;
+    }
+    isolate.kill();
+    receivePort.close();
+    answerPort.close();
+    _isInitializeFlag = false;
+  }
+}
+
+class AudioProcessingWhisperStreaming {
+  final SpeechToTextIsolate _ailiaSpeechModel = SpeechToTextIsolate();
+
+  Future<void> open(File onnx_encoder_file, File onnx_decoder_file, File vad_file, int env_id, String type, String lang, bool virtualMemory, Function intermediateCallback, Function messageCallback, Function finishCallback) async{
+    int typeId = 0;
+    if (type == "whisper_tiny"){
+      typeId = ailia_speech_dart.AILIA_SPEECH_MODEL_TYPE_WHISPER_MULTILINGUAL_TINY;
+    }
+    if (type == "whisper_small"){
+      typeId = ailia_speech_dart.AILIA_SPEECH_MODEL_TYPE_WHISPER_MULTILINGUAL_SMALL;
+    }
+    if (type == "whisper_medium"){
+      // Please add com.apple.developer.kernel.increased-memory-limit for iOS
+      typeId = ailia_speech_dart.AILIA_SPEECH_MODEL_TYPE_WHISPER_MULTILINGUAL_MEDIUM;
+    }
+    if (type == "whisper_large_v3_turbo"){
+      // Please add com.apple.developer.kernel.increased-memory-limit for iOS
+      typeId = ailia_speech_dart.AILIA_SPEECH_MODEL_TYPE_WHISPER_MULTILINGUAL_LARGE_V3;
+    }
+    if (virtualMemory){
+      Directory path = await getTemporaryDirectory();
+      AiliaModel.setTemporaryCachePath(path.path);
+    }
+    _ailiaSpeechModel.init(intermediateCallback, messageCallback, finishCallback, onnx_encoder_file, onnx_decoder_file, vad_file, typeId, false, lang, true, env_id, virtualMemory);
+  }
+
+  void send(List<double> pcm, int samplesPerSecond){
+    _ailiaSpeechModel.send(pcm, samplesPerSecond, 1);
+  }
+
+  void terminate(){
+    _ailiaSpeechModel.terminate();
+  }
+
+  void close(){
+    _ailiaSpeechModel.close();
+  }
+
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,6 +14,7 @@ import 'package:path/path.dart';
 // mic
 import 'package:mic_stream/mic_stream.dart';
 import 'package:ailia_speech/ailia_speech_model.dart';
+import 'package:permission_handler/permission_handler.dart';
 
 // image
 import 'dart:ui' as ui;
@@ -394,6 +395,8 @@ class _AiliaModelsFlutterState extends State<AiliaModelsFlutter> {
         listener!.cancel();
         listener = null;
       }
+
+      await Permission.microphone.request();
 
       int sampleRate = 44100;
       stream = MicStream.microphone(audioSource: AudioSource.DEFAULT, sampleRate: sampleRate, channelConfig: ChannelConfig.CHANNEL_IN_MONO, audioFormat: AudioFormat.ENCODING_PCM_16BIT);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -109,6 +109,7 @@ class _AiliaModelsFlutterState extends State<AiliaModelsFlutter> {
     case "whisper_tiny":
     case "whisper_small":
     case "whisper_medium":
+    case "whisper_medium_with_virtual_memory":
     case "whisper_large_v3_turbo":
     case "whisper_large_v3_turbo_with_virtual_memory":
       _ailiaAudioProcessingWhisper(isSelectedItem!);
@@ -543,6 +544,7 @@ class _AiliaModelsFlutterState extends State<AiliaModelsFlutter> {
     modelList.add('whisper_tiny');
     modelList.add('whisper_small');
     modelList.add('whisper_medium');
+    modelList.add('whisper_medium_with_virtual_memory');
     modelList.add('whisper_large_v3_turbo');
     modelList.add('whisper_large_v3_turbo_with_virtual_memory');
     modelList.add('multilingual-e5');

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -337,7 +337,7 @@ class _AiliaModelsFlutterState extends State<AiliaModelsFlutter> {
 
   void _intermediateCallback(List<SpeechText> text){
       setState(() {
-        predict_result = text[0].text;
+        predict_result = text[0].text + "...";
       });
   }
 
@@ -396,8 +396,7 @@ class _AiliaModelsFlutterState extends State<AiliaModelsFlutter> {
       }
 
       int sampleRate = 44100;
-      //MicStream.shouldRequestPermission(true);
-      stream = MicStream.microphone(audioSource: AudioSource.DEFAULT, sampleRate: sampleRate, channelConfig: ChannelConfig.CHANNEL_IN_STEREO, audioFormat: AudioFormat.ENCODING_PCM_16BIT);
+      stream = MicStream.microphone(audioSource: AudioSource.DEFAULT, sampleRate: sampleRate, channelConfig: ChannelConfig.CHANNEL_IN_MONO, audioFormat: AudioFormat.ENCODING_PCM_16BIT);
       listener = stream!.listen(_processSamples);
     });
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -355,7 +355,7 @@ class _AiliaModelsFlutterState extends State<AiliaModelsFlutter> {
   void _finishCallback(){
     whisper.close();
     setState(() {
-      predict_result = "You can run new whisper instance.";
+      predict_result = "Terminate success. You can run new whisper instance.";
     });
     terminating = false;
   }
@@ -411,7 +411,8 @@ class _AiliaModelsFlutterState extends State<AiliaModelsFlutter> {
         return;
       }
 
-      await whisper.open(onnx_encoder_file, onnx_decoder_file, vad_file, selectedEnvId, modelType, _intermediateCallback, _messageCallback, _finishCallback);
+      String lang = "ja";
+      await whisper.open(onnx_encoder_file, onnx_decoder_file, vad_file, selectedEnvId, modelType, lang, _intermediateCallback, _messageCallback, _finishCallback);
       if (Platform.isIOS){
         await Permission.microphone.request();
       }

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -12,6 +12,7 @@ import ailia_speech
 import ailia_tokenizer
 import ailia_voice
 import audioplayers_darwin
+import mic_stream
 import path_provider_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
@@ -22,5 +23,6 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AiliaTokenizerPlugin.register(with: registry.registrar(forPlugin: "AiliaTokenizerPlugin"))
   AiliaVoicePlugin.register(with: registry.registrar(forPlugin: "AiliaVoicePlugin"))
   AudioplayersDarwinPlugin.register(with: registry.registrar(forPlugin: "AudioplayersDarwinPlugin"))
+  MicStreamPlugin.register(with: registry.registrar(forPlugin: "MicStreamPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
 }

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -14,6 +14,8 @@ PODS:
   - audioplayers_darwin (0.0.1):
     - FlutterMacOS
   - FlutterMacOS (1.0.0)
+  - mic_stream (0.5.2):
+    - FlutterMacOS
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -27,6 +29,7 @@ DEPENDENCIES:
   - ailia_voice (from `Flutter/ephemeral/.symlinks/plugins/ailia_voice/macos`)
   - audioplayers_darwin (from `Flutter/ephemeral/.symlinks/plugins/audioplayers_darwin/macos`)
   - FlutterMacOS (from `Flutter/ephemeral`)
+  - mic_stream (from `Flutter/ephemeral/.symlinks/plugins/mic_stream/macos`)
   - path_provider_foundation (from `Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin`)
 
 EXTERNAL SOURCES:
@@ -46,6 +49,8 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/audioplayers_darwin/macos
   FlutterMacOS:
     :path: Flutter/ephemeral
+  mic_stream:
+    :path: Flutter/ephemeral/.symlinks/plugins/mic_stream/macos
   path_provider_foundation:
     :path: Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin
 
@@ -58,6 +63,7 @@ SPEC CHECKSUMS:
   ailia_voice: 2ed4de5c9dee2b2be67c8877d8076fc4518268ac
   audioplayers_darwin: dcad41de4fbd0099cb3749f7ab3b0cb8f70b810c
   FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
+  mic_stream: c3bc8a10c5451a0f5ef75a54a75caf25a3d146c4
   path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
 
 PODFILE CHECKSUM: 236401fc2c932af29a9fcf0e97baeeb2d750d367

--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -8,5 +8,7 @@
 	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
 </dict>
 </plist>

--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -4,5 +4,11 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<false/>
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+	<key>com.apple.security.network.server</key>
+	<true/>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
 </dict>
 </plist>

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -310,6 +310,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.11.0"
+  mic_stream:
+    dependency: "direct main"
+    description:
+      name: mic_stream
+      sha256: "1db1ec77bdd8ffc0d1c5cc606398612930312a96462220add5ea24aa9da73210"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.1+2"
   path:
     dependency: transitive
     description:
@@ -366,6 +374,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
+  permission_handler:
+    dependency: transitive
+    description:
+      name: permission_handler
+      sha256: "18bf33f7fefbd812f37e72091a15575e72d5318854877e0e4035a24ac1113ecb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "11.3.1"
+  permission_handler_android:
+    dependency: transitive
+    description:
+      name: permission_handler_android
+      sha256: "71bbecfee799e65aff7c744761a57e817e73b738fedf62ab7afd5593da21f9f1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "12.0.13"
+  permission_handler_apple:
+    dependency: transitive
+    description:
+      name: permission_handler_apple
+      sha256: e6f6d73b12438ef13e648c4ae56bd106ec60d17e90a59c4545db6781229082a0
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.4.5"
+  permission_handler_html:
+    dependency: transitive
+    description:
+      name: permission_handler_html
+      sha256: af26edbbb1f2674af65a8f4b56e1a6f526156bc273d0e65dd8075fab51c78851
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.3+2"
+  permission_handler_platform_interface:
+    dependency: transitive
+    description:
+      name: permission_handler_platform_interface
+      sha256: e9c8eadee926c4532d0305dff94b85bf961f16759c3af791486613152af4b4f9
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.2.3"
+  permission_handler_windows:
+    dependency: transitive
+    description:
+      name: permission_handler_windows
+      sha256: "1a790728016f79a41216d88672dbc5df30e686e811ad4e698bfc51f76ad91f1e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1"
   petitparser:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -375,7 +375,7 @@ packages:
     source: hosted
     version: "2.3.0"
   permission_handler:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: permission_handler
       sha256: "18bf33f7fefbd812f37e72091a15575e72d5318854877e0e4035a24ac1113ecb"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -65,6 +65,7 @@ dependencies:
   wav:
   image:
   audioplayers:
+  mic_stream:
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -66,6 +66,7 @@ dependencies:
   image:
   audioplayers:
   mic_stream:
+  permission_handler:
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -13,6 +13,7 @@
 #include <ailia_tokenizer/ailia_tokenizer_plugin_c_api.h>
 #include <ailia_voice/ailia_voice_plugin_c_api.h>
 #include <audioplayers_windows/audioplayers_windows_plugin.h>
+#include <permission_handler_windows/permission_handler_windows_plugin.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   AiliaPluginCApiRegisterWithRegistrar(
@@ -29,4 +30,6 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("AiliaVoicePluginCApi"));
   AudioplayersWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("AudioplayersWindowsPlugin"));
+  PermissionHandlerWindowsPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("PermissionHandlerWindowsPlugin"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -10,6 +10,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   ailia_tokenizer
   ailia_voice
   audioplayers_windows
+  permission_handler_windows
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST


### PR DESCRIPTION
- mic_streamを使用してマイクの音声をストリーミング
- VADで音声区切りで文字起こしを実装
- intermediate_callbackで途中の結果をリアルタイム表示
- liveTranscribeは不使用
- isolateを使用してUIプロセスとは分離して処理
- iOSの場合、micのPermissionが必要なので付与
- macOS M2とiPhone 15 Pro Maxで動作確認

Whisper Large V3 Turboを使用する場合はCapabilityにIncreaseMemoryLimitを追加する必要があります。

![スクリーンショット 2024-10-28 12 56 48](https://github.com/user-attachments/assets/a7075a1c-9f33-4b1f-be2f-a9099a57ad7f)

iOSのmicのPermissionについては下記を参照してください。
https://zenn.dev/kazu098/articles/208cc780cf4d0c

iOSでXcodeからiOSの転送がうまくいかない場合は下記を参照してください。
https://stackoverflow.com/questions/77304874/framework-pods-runner-not-found