### PR TITLE
Rebuild the STT page when microphone recognition stops

### DIFF
--- a/lib/screens/demo/stt_demo_page.dart
+++ b/lib/screens/demo/stt_demo_page.dart
@@ -105,11 +105,15 @@ class _SttDemoPageState extends State<SttDemoPage> with SafeSetStateMixin {
       return;
     }
     _listener!.cancel();
-    _listener = null;
     _stopMicRecorder();
-    _recStart = null;
     _whisperStreaming.terminate();
     _terminating = true;
+    // Rebuild so the Stop button returns to Run; without this the page
+    // only repaints when new transcript text happens to arrive.
+    safeSetState(() {
+      _listener = null;
+      _recStart = null;
+    });
     _session.showResult("Please wait terminate.");
   }
 


### PR DESCRIPTION
_stopRecognition mutated the recognition state without setState, so the Run / Stop button and the REC indicator only refreshed when new transcript text happened to arrive. With SenseVoice the stop drain usually produces no further text, leaving the button stuck on Stop. Wrap the state changes in safeSetState so stopping always returns the button to Run.