### PR TITLE
Fall back to platform emoji fonts so emoji do not render as tofu

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,14 +11,28 @@ void main() {
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
+  // Desktop Flutter does not fall back to the platform emoji font on its
+  // own, so emoji in model output would render as tofu without this.
+  static const _emojiFontFallback = [
+    'Apple Color Emoji', // macOS / iOS
+    'Segoe UI Emoji', // Windows
+    'Noto Color Emoji', // Linux / Android
+  ];
+
   // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
+    final theme = ThemeData(
+      colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
+      useMaterial3: true,
+    );
     return MaterialApp(
       title: 'ailia MODELS Flutter',
-      theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-        useMaterial3: true,
+      theme: theme.copyWith(
+        textTheme:
+            theme.textTheme.apply(fontFamilyFallback: _emojiFontFallback),
+        primaryTextTheme: theme.primaryTextTheme
+            .apply(fontFamilyFallback: _emojiFontFallback),
       ),
       builder: (context, child) => RepaintBoundary(
         key: screenshotBoundaryKey,


### PR DESCRIPTION
Desktop Flutter does not fall back to the system emoji font on its own, so emoji in LLM output rendered as empty boxes. Add Apple Color Emoji / Segoe UI Emoji / Noto Color Emoji to the theme font fallback.