### PR TITLE
Run VLM inference in an isolate and add Gemma 4 E2B multimodal

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ flutter run
 | [gemma2](/lib/large_language_model/) | [gemma-2-2b](https://huggingface.co/google/gemma-2-2b) | llama.cpp | 1.1.0 and later| |
 | [gemma3-multimodal](/lib/large_language_model/) | [gemma-3-4b-it](https://huggingface.co/google/gemma-3-4b-it) | llama.cpp | 1.4.2 and later | |
 | [gemma4-e2b](/lib/large_language_model/) | [gemma-4-E2B-it](https://huggingface.co/google/gemma-4-E2B-it) | llama.cpp | 1.4.2 and later | |
+| [gemma4-e2b-multimodal](/lib/large_language_model/) | [gemma-4-E2B-it](https://huggingface.co/google/gemma-4-E2B-it) | llama.cpp | 1.4.2 and later | |
 
 ### Natural Language Processing
 

--- a/lib/large_language_model/multimodal_large_language_model.dart
+++ b/lib/large_language_model/multimodal_large_language_model.dart
@@ -1,164 +1,190 @@
 import 'dart:io';
-import 'dart:typed_data';
+import 'dart:isolate';
+
 import 'package:ailia_llm/ailia_llm_model.dart';
 import 'package:http/http.dart' as http;
 
-class MultimodalLargeLanguageModel {
-  final AiliaLLMModel _ailiaLLMModel = AiliaLLMModel();
+/// Everything the inference isolate needs, passed as the spawn argument.
+class _VlmRequest {
+  final SendPort sendPort;
+  final String modelPath;
+  final String mmprojPath;
+  final String backend;
+  final int nCtx;
+  final String systemPrompt;
+  final String inputText;
+  final String imagePath;
 
-  List<String> getModelList(){
-    List<String> modelList = List<String>.empty(growable: true);
-    
-    // Multimodal Gemma3 model
-    modelList.add("gemma");
-    modelList.add("gemma-3-4b-it-Q4_K_M.gguf");
-    modelList.add("gemma");
-    modelList.add("gemma-3-4b-it-GGUF_mmproj-model-f16.gguf");
+  const _VlmRequest({
+    required this.sendPort,
+    required this.modelPath,
+    required this.mmprojPath,
+    required this.backend,
+    required this.nCtx,
+    required this.systemPrompt,
+    required this.inputText,
+    required this.imagePath,
+  });
+}
 
-    return modelList;
-  }
-
-  List<Map<String, dynamic>> messages = List<Map<String, dynamic>>.empty(growable:true);
-  String systemPrompt = "";
-
-  void open(File model, File mmproj){
-    int nCtx = 8192; // Context size for multimodal model
-
-    // Initialize backend list before opening model
+/// Runs one open -> generate -> close cycle off the UI thread, streaming
+/// each token back as {"delta": ...} and ending with {"done": fullText}
+/// or {"error": message}.
+void _vlmIsolateFunc(_VlmRequest request) {
+  final llm = AiliaLLMModel();
+  try {
     List<String> backendList = AiliaLLMModel.getBackendList();
-
-    if (backendList.isEmpty) {
-      throw Exception("No backends available for ailia LLM");
+    if (!backendList.contains(request.backend)) {
+      throw Exception(
+          "Backend '${request.backend}' not available. Available: $backendList");
     }
 
-    // Use the first available backend
-    String backend = backendList[0];
+    llm.open(request.modelPath, request.nCtx, backend: request.backend);
+    llm.openMultimodalProjectorFile(request.mmprojPath);
 
-    // Open the base text model
-    _ailiaLLMModel.open(model.path, nCtx, backend: backend);
-
-    // Open the multimodal projector
-    _ailiaLLMModel.openMultimodalProjectorFile(mmproj.path);
-
-    // Get multimodal capabilities to verify setup
-    Map<String, bool> capabilities = _ailiaLLMModel.getMultimodalCapabilities();
-    if (!capabilities['vision']!) {
+    Map<String, bool> capabilities = llm.getMultimodalCapabilities();
+    if (capabilities['vision'] != true) {
       throw Exception("Vision capabilities not available");
     }
-  }
 
-  void openWithBackend(File model, File mmproj, String selectedBackend){
-    int nCtx = 8192; // Context size for multimodal model
-
-    // Initialize backend list before opening model
-    List<String> backendList = AiliaLLMModel.getBackendList();
-
-    if (backendList.isEmpty) {
-      throw Exception("No backends available for ailia LLM");
+    final messages = <Map<String, dynamic>>[];
+    if (request.systemPrompt.isNotEmpty) {
+      messages.add({"role": "system", "content": request.systemPrompt});
     }
-
-    // Map environment names to backend names
-    String backend;
-    if (selectedBackend.contains("Vulkan") || selectedBackend.contains("GPU")) {
-      backend = "Vulkan";
-    } else if (selectedBackend.contains("Metal")) {
-      backend = "Metal";
-    } else {
-      backend = "CPU";
-    }
-
-    // Verify the selected backend is available
-    if (!backendList.contains(backend)) {
-      throw Exception("Selected backend '$backend' not available. Available: $backendList");
-    }
-
-    // Open the base text model with selected backend
-    _ailiaLLMModel.open(model.path, nCtx, backend: backend);
-
-    // Open the multimodal projector
-    _ailiaLLMModel.openMultimodalProjectorFile(mmproj.path);
-
-    // Get multimodal capabilities to verify setup
-    Map<String, bool> capabilities = _ailiaLLMModel.getMultimodalCapabilities();
-    if (!capabilities['vision']!) {
-      throw Exception("Vision capabilities not available");
-    }
-  }
-
-  /// Opens the model with an exact backend name taken from
-  /// AiliaLLMModel.getBackendList() (e.g. CPU / Vulkan / OpenCL / Metal).
-  void openWithBackendName(File model, File mmproj, String backend){
-    int nCtx = 8192; // Context size for multimodal model
-
-    List<String> backendList = AiliaLLMModel.getBackendList();
-    if (!backendList.contains(backend)) {
-      throw Exception("Backend '$backend' not available. Available: $backendList");
-    }
-
-    _ailiaLLMModel.open(model.path, nCtx, backend: backend);
-
-    // Open the multimodal projector
-    _ailiaLLMModel.openMultimodalProjectorFile(mmproj.path);
-
-    // Get multimodal capabilities to verify setup
-    Map<String, bool> capabilities = _ailiaLLMModel.getMultimodalCapabilities();
-    if (!capabilities['vision']!) {
-      throw Exception("Vision capabilities not available");
-    }
-  }
-
-  void setSystemPrompt(String prompt){
-    systemPrompt = prompt;
-    _addSystemPrompt();
-  }
-
-  void _addSystemPrompt(){
-    if (systemPrompt == ""){
-      return;
-    }
-    messages.add({"role": "system", "content": systemPrompt});
-  }
-
-  String chatWithImage(String inputText, String imagePath){
-    if (_ailiaLLMModel.contextFull()){
-      messages = List<Map<String, dynamic>>.empty(growable:true);
-      _addSystemPrompt();
-    }
-
-    // Create multimodal message with image
-    String multimodalContent = "$inputText <__media__>";
-    Map<String, dynamic> userMessage = {
+    messages.add({
       "role": "user",
-      "content": multimodalContent,
+      "content": "${request.inputText} <__media__>",
       "media_data": [
         {
           "media_type": "image",
-          "file_path": imagePath,
+          "file_path": request.imagePath,
           "width": 0,
           "height": 0
         }
       ]
-    };
+    });
+    llm.setPrompt(messages);
 
-    messages.add(userMessage);
-
-    _ailiaLLMModel.setMultimodalPrompt(messages);
-
-    String text = "";
-    while(true){
-      String? deltaText = _ailiaLLMModel.generate();
-      if (deltaText == null){
+    final text = StringBuffer();
+    while (true) {
+      String? deltaText = llm.generate();
+      if (deltaText == null) {
         break;
       }
-      text = text + deltaText;
+      text.write(deltaText);
+      request.sendPort.send({"delta": deltaText});
     }
+    request.sendPort.send({"done": text.toString()});
+  } catch (e) {
+    request.sendPort.send({"error": "$e"});
+  } finally {
+    llm.close();
+  }
+}
 
-    messages.add({"role": "assistant", "content": text});
-    return text;
+/// Multimodal (image + text) LLM inference. The heavy native calls
+/// (model load and token generation) run in a spawned isolate so the UI
+/// thread never blocks; tokens stream back through [chatWithImage]'s
+/// onDelta callback.
+class MultimodalLargeLanguageModel {
+  Isolate? _isolate;
+  ReceivePort? _receivePort;
+
+  static String modelFileName(String type) {
+    if (type == 'gemma4-e2b-multimodal') {
+      return "gemma-4-E2B-it-Q4_K_M.gguf";
+    }
+    return "gemma-3-4b-it-Q4_K_M.gguf";
   }
 
-  void close(){
-    _ailiaLLMModel.close();
+  static String mmprojFileName(String type) {
+    if (type == 'gemma4-e2b-multimodal') {
+      return "gemma-4-E2B-it-mmproj-F16.gguf";
+    }
+    return "gemma-3-4b-it-GGUF_mmproj-model-f16.gguf";
+  }
+
+  static int contextSize(String type) {
+    if (type == 'gemma4-e2b-multimodal') {
+      return 16384;
+    }
+    return 8192;
+  }
+
+  List<String> getModelList([String type = 'gemma3-multimodal']) {
+    List<String> modelList = List<String>.empty(growable: true);
+
+    modelList.add("gemma");
+    modelList.add(modelFileName(type));
+    modelList.add("gemma");
+    modelList.add(mmprojFileName(type));
+
+    return modelList;
+  }
+
+  /// Describes [imagePath] guided by [inputText], reporting each
+  /// generated token through [onDelta]. Cancelling with [cancel]
+  /// resolves the future with the text generated so far.
+  Future<String> chatWithImage({
+    required File model,
+    required File mmproj,
+    required String backend,
+    required int nCtx,
+    required String systemPrompt,
+    required String inputText,
+    required String imagePath,
+    void Function(String delta)? onDelta,
+  }) async {
+    final receivePort = ReceivePort();
+    _receivePort = receivePort;
+    _isolate = await Isolate.spawn(
+      _vlmIsolateFunc,
+      _VlmRequest(
+        sendPort: receivePort.sendPort,
+        modelPath: model.path,
+        mmprojPath: mmproj.path,
+        backend: backend,
+        nCtx: nCtx,
+        systemPrompt: systemPrompt,
+        inputText: inputText,
+        imagePath: imagePath,
+      ),
+      onExit: receivePort.sendPort,
+    );
+
+    final text = StringBuffer();
+    try {
+      await for (final message in receivePort) {
+        if (message == null) {
+          // onExit fired without a result: the isolate died.
+          throw Exception("Inference isolate exited unexpectedly");
+        }
+        final map = message as Map;
+        if (map.containsKey("delta")) {
+          final delta = map["delta"] as String;
+          text.write(delta);
+          onDelta?.call(delta);
+        } else if (map.containsKey("done")) {
+          return map["done"] as String;
+        } else if (map.containsKey("error")) {
+          throw Exception(map["error"]);
+        }
+      }
+      // cancel() closed the port mid-run.
+      return text.toString();
+    } finally {
+      receivePort.close();
+      _receivePort = null;
+      _isolate = null;
+    }
+  }
+
+  /// Kills a run in flight (e.g. the page was disposed).
+  void cancel() {
+    _isolate?.kill(priority: Isolate.immediate);
+    _isolate = null;
+    _receivePort?.close();
+    _receivePort = null;
   }
 
   // Helper method to download a file

--- a/lib/model_catalog.dart
+++ b/lib/model_catalog.dart
@@ -89,6 +89,8 @@ const List<ModelInfo> modelCatalog = [
       'gemma4-e2b', 'Gemma 4 E2B', 'Large Language Model', ModelInputKind.text),
   ModelInfo('gemma3-multimodal', 'Gemma 3 4B Multimodal',
       'Large Language Model', ModelInputKind.imageText),
+  ModelInfo('gemma4-e2b-multimodal', 'Gemma 4 E2B Multimodal',
+      'Large Language Model', ModelInputKind.imageText),
 ];
 
 /// Remote (folder, filename) pairs for the image demos, shared by the

--- a/lib/screens/demo/vlm_demo_page.dart
+++ b/lib/screens/demo/vlm_demo_page.dart
@@ -26,6 +26,7 @@ class VlmDemoPage extends StatefulWidget {
 class _VlmDemoPageState extends State<VlmDemoPage> with SafeSetStateMixin {
   final DemoSession _session = DemoSession();
   final CameraInput _camera = CameraInput();
+  final MultimodalLargeLanguageModel _vlm = MultimodalLargeLanguageModel();
 
   // Query for the multimodal (image + text) LLM demo.
   final TextEditingController _queryController =
@@ -44,6 +45,8 @@ class _VlmDemoPageState extends State<VlmDemoPage> with SafeSetStateMixin {
   void dispose() {
     _queryController.dispose();
     _camera.dispose();
+    // Stop the inference isolate if a run is still in flight.
+    _vlm.cancel();
     _session.dispose();
     super.dispose();
   }
@@ -87,12 +90,11 @@ class _VlmDemoPageState extends State<VlmDemoPage> with SafeSetStateMixin {
         } else {
           _camera.clearCapture();
         }
-        await _runGemma3Multimodal();
+        await _runMultimodal();
       });
 
-  Future<void> _runGemma3Multimodal() async {
-    MultimodalLargeLanguageModel multimodalLLM = MultimodalLargeLanguageModel();
-    List<String> modelList = multimodalLLM.getModelList();
+  Future<void> _runMultimodal() async {
+    List<String> modelList = _vlm.getModelList(widget.model.id);
     if (!await _session.downloadModelList(modelList)) {
       return;
     }
@@ -122,20 +124,21 @@ class _VlmDemoPageState extends State<VlmDemoPage> with SafeSetStateMixin {
       _session.clearStatus();
       await Future.delayed(const Duration(milliseconds: 100));
 
-      await _performInference(multimodalLLM, imagePath);
+      await _performInference(imagePath);
     } catch (e) {
       _session.showError(e);
     }
   }
 
-  Future<void> _performInference(
-      MultimodalLargeLanguageModel multimodalLLM, String imagePath) async {
+  Future<void> _performInference(String imagePath) async {
     try {
       _session.showResult("Loading model with selected backend...");
 
-      File modelFile = File(await getModelPath("gemma-3-4b-it-Q4_K_M.gguf"));
-      File mmprojFile =
-          File(await getModelPath("gemma-3-4b-it-GGUF_mmproj-model-f16.gguf"));
+      final type = widget.model.id;
+      File modelFile = File(
+          await getModelPath(MultimodalLargeLanguageModel.modelFileName(type)));
+      File mmprojFile = File(await getModelPath(
+          MultimodalLargeLanguageModel.mmprojFileName(type)));
 
       String inputText = _queryController.text.trim();
 
@@ -144,17 +147,33 @@ class _VlmDemoPageState extends State<VlmDemoPage> with SafeSetStateMixin {
       // ailia LLM has its own backend list; use the LLM selection.
       String selectedBackend = BackendState.instance.selectedLlmBackend.value;
 
-      multimodalLLM.openWithBackendName(modelFile, mmprojFile, selectedBackend);
-      multimodalLLM.setSystemPrompt("画像を2-3文で簡潔に説明してください。");
-      String outputText = multimodalLLM.chatWithImage(inputText, imagePath);
+      // Generation runs in an isolate; stream tokens into the result
+      // panel, repainting at most once per frame.
+      final reply = StringBuffer();
+      int lastPaintMs = 0;
+      String outputText = await _vlm.chatWithImage(
+        model: modelFile,
+        mmproj: mmprojFile,
+        backend: selectedBackend,
+        nCtx: MultimodalLargeLanguageModel.contextSize(type),
+        systemPrompt: "画像を2-3文で簡潔に説明してください。",
+        inputText: inputText,
+        imagePath: imagePath,
+        onDelta: (delta) {
+          reply.write(delta);
+          final nowMs = DateTime.now().millisecondsSinceEpoch;
+          if (nowMs - lastPaintMs >= 33) {
+            lastPaintMs = nowMs;
+            _session.showResult(reply.toString());
+          }
+        },
+      );
 
       int endTime = DateTime.now().millisecondsSinceEpoch;
       String profileText =
           "processing time : ${endTime - startTime} ms";
 
       _session.showResult("$outputText\n$profileText");
-
-      multimodalLLM.close();
     } catch (e) {
       _session.showError("Inference Error: $e");
     }

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -27,6 +27,9 @@ const Map<String, String> _markerFiles = {
   'gemma2': 'gemma-2-2b-it-Q4_K_M.gguf',
   'gemma4-e2b': 'gemma-4-E2B-it-Q4_K_M.gguf',
   'gemma3-multimodal': 'gemma-3-4b-it-Q4_K_M.gguf',
+  // The text model file is shared with gemma4-e2b, so the badge keys
+  // off the multimodal projector instead.
+  'gemma4-e2b-multimodal': 'gemma-4-E2B-it-mmproj-F16.gguf',
 };
 
 /// Top screen: model cards grouped by category. Selecting a card


### PR DESCRIPTION
The VLM demo loaded the model and generated tokens on the UI thread, freezing the app for the whole run. Move the open -> generate -> close cycle into a spawned isolate that streams tokens back to the page, so the reply now renders progressively like the chat demo.

Also add Gemma 4 E2B as a second VLM (gemma-4-E2B-it-Q4_K_M.gguf + gemma-4-E2B-it-mmproj-F16.gguf, nCtx 16384), matching ailia-models-unity.